### PR TITLE
Fix: use cryptographically secure ID generation

### DIFF
--- a/lib/study/synchronizeHistory.ts
+++ b/lib/study/synchronizeHistory.ts
@@ -1,11 +1,13 @@
 "use server"
 
+import { promisify } from "node:util"
+import { randomBytes } from "node:crypto";
 import { sql } from "@vercel/postgres";
 import { cookies } from "next/headers";
 import { GameHistory } from "./GameHistory";
 
-function generateNewPlayerId(): string {
-    const newPlayerId = Math.random().toString(36).substring(2)
+async function generateNewPlayerId(): Promise<string> {
+    const newPlayerId = (await promisify(randomBytes)(20)).toString('hex');
     return newPlayerId
 }
 
@@ -18,7 +20,7 @@ async function setPlayerId(playerId: string) {
 export async function getPlayerId(): Promise<string> {
     const playerId = cookies().get('id')
     if (playerId === undefined) {
-        const newPlayerId = generateNewPlayerId()
+        const newPlayerId = await generateNewPlayerId()
         setPlayerId(newPlayerId)
         return newPlayerId
     } else {


### PR DESCRIPTION
Replace the method of generating user IDs with a promisified one from the node:crypto module, that uses a CSPRNG and prevents prediction of other user IDs.

The ID is generated from 20 bytes of randomBytes() output and converted to a 40 character hex string.

I have made this a public PR as discussion has indicated this issue should have minimal impact (there are no active study participants and most tables in the database take just insertions).