### PR TITLE
Validate user-provided filenames

### DIFF
--- a/components/game/GameLoader.tsx
+++ b/components/game/GameLoader.tsx
@@ -1,6 +1,5 @@
 import { makeInitializationDataFromProblemFileData } from "lib/game/Initialization"
-import { promises as fs } from "fs"
-import { loadStudyConfiguration } from "lib/game/LoadProblems"
+import { loadProblemData, loadStudyConfiguration } from "lib/game/LoadProblems"
 import { parseProblemFile } from "lib/parsing/Semantics"
 import { getNextProblem } from "lib/study/LevelConfiguration"
 import { Suspense } from "react"
@@ -23,9 +22,7 @@ function LoadingScreen() {
 
 export async function GameLoader({ configId, problemId }: { configId: string, problemId: string }) {
     const configuration = await loadStudyConfiguration(configId)
-
-    const problemFile = problemId + ".pl"
-    const problemData = await fs.readFile(process.cwd() + "/problems/" + problemFile, "utf-8")
+    const problemData = await loadProblemData(problemId);
 
     const nextProblem = getNextProblem(configuration, problemId)
     const { initialDiagramFromTutorialSpecification, settings, tutorialSteps } = getTutorialProps(problemId)

--- a/lib/game/LoadProblems.ts
+++ b/lib/game/LoadProblems.ts
@@ -3,6 +3,20 @@
 import { promises as fs } from "fs"
 import path from 'path'
 import { StudyConfiguration } from "lib/study/Types"
+import { notFound } from "next/navigation";
+
+const FILE_VALIDATOR_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+async function readFileWith404(filepath: string): Promise<string> {
+    try {
+        return await fs.readFile(filepath, "utf-8")
+    } catch (err) {
+        if (err.code === "ENAMETOOLONG" || err.code === "ENOENT") {
+            notFound()
+        }
+        throw err; 
+    }
+}
 
 export async function loadAllProblemsInDirectory(): Promise<string[]> {
     const pathToProblems = process.cwd() + "/problems/"
@@ -20,9 +34,17 @@ export async function loadAllStudyConfigurations(): Promise<string[]> {
     return withExtensionRemoved
 }
 
-export async function loadStudyConfiguration(configurationIdentifier: string): Promise<StudyConfiguration> { 
+export async function loadStudyConfiguration(configurationIdentifier: string): Promise<StudyConfiguration> {
+    if (!FILE_VALIDATOR_REGEX.test(configurationIdentifier)) notFound();
     const configurationFilePath = path.resolve('study_setup', configurationIdentifier + ".json")
-    const configurationFile = await fs.readFile(configurationFilePath, "utf-8")
+    const configurationFile = await readFileWith404(configurationFilePath);
     const configuration : StudyConfiguration = JSON.parse(configurationFile)
     return configuration
+}
+
+export async function loadProblemData(problemId: string): Promise<string> { 
+    if (!FILE_VALIDATOR_REGEX.test(problemId)) notFound();
+    const problemFilePath = path.resolve('problems', problemId + ".pl");
+    const problemData = await readFileWith404(problemFilePath);
+    return problemData;
 }


### PR DESCRIPTION
This PR resolves #26. 

The commit already describes the changes, but with a little more focus on intention, they are that: 

- User-provided parameters that map to filenames are tested against the regex `/^[a-zA-Z0-9_-]+$/`. This prevents path traversal. 
- Certain filesystem errors are caught and replaced with an error representing that the page was not found. The app router converts this into a 404 page for the user. 
- File loading logic is moved from `GameLoader.tsx` to `LoadProblems.ts`. 