### PR TITLE
Improve parser errors

### DIFF
--- a/lib/parsing/Parser.ts
+++ b/lib/parsing/Parser.ts
@@ -63,7 +63,13 @@ export const parser: PrologParser = new PrologParser()
 
 function handleErrors(errors: IRecognitionException[]) {
     if (errors.length > 0) {
-        const msg = errors.map((error) => `[${error.name}] ${error.message}`).join('\n')
+        const getPos = (error: IRecognitionException) => {
+            const makeMsg = error.token.startLine !== null 
+                && error.token.startColumn !== null;
+            if (!makeMsg) return "";
+            return `. Occurs on ${error.token.startLine}:${error.token.startColumn}`
+        }
+        const msg = errors.map((error) => `[${error.name}] ${error.message}${getPos(error)}`).join('\n')
         throw new Error(msg)
     }
 }


### PR DESCRIPTION
Include line number and column information in parser errors. 

For example, for the following problem file (where `·` represents a space):
```
b(1,1).
 ·
b(f(A),A).
```
The error `[MismatchedTokenException] Expecting token of type --> FullStop <-- but found --> ' ' <--. Occurs on 2:2` is now shown. 

If the second line were instead `a(2,2)).` the error would instead be `[MismatchedTokenException] Expecting token of type --> FullStop <-- but found --> ')' <--. Occurs on 2:7`. 

