### PR TITLE
Extend slot highlighting over gadgets

### DIFF
--- a/components/game/gadget/Hole.tsx
+++ b/components/game/gadget/Hole.tsx
@@ -21,14 +21,29 @@ export function Hole(props: HoleProps) {
 
     const value = getAssignedValue(props.term, assignment, termEnumeration);
 
+    // Make use of assigned values so that number terms share
+    // the same representative as the holes they are unified with.
+    const findRepresentativeWithNumbers = (term: Term) => {
+        if ("function" in term) throw Error("Unreachable case");
+        if ("number" in term) return term.label;
+
+        const termValue = assignment.getAssignedValue(term.variable);
+        if (termValue === undefined || !("number" in termValue)) 
+            return assignment.findRepresentative(term.variable);
+        return termValue.label;
+    }
+
     const makeFocusProps = (term: Term) => {
-        if ("variable" in term) {
-            return {
-                isFocussed: focussedHole === term.variable,
-                onMouseEnter: () => focus(term.variable),
-            }
-        } else {
-            return undefined
+        if ("function" in term) return undefined;
+
+        const termRepresentative = findRepresentativeWithNumbers(term);
+        const focussedRepresentative = focussedHole === undefined ? 
+              undefined
+            : findRepresentativeWithNumbers(focussedHole);
+
+        return {
+            isFocussed: termRepresentative === focussedRepresentative,
+            onMouseEnter: () => focus(term),
         }
     }
 

--- a/lib/game/GameLogic.ts
+++ b/lib/game/GameLogic.ts
@@ -16,7 +16,8 @@ export function getGadgetRelations(statement: string, id: GadgetId): Map<CellPos
         relations.set(OUTPUT_POSITION, axiomWithFreshVariables.conclusion)
         return relations
     } else {
-        return new Map<CellPosition, Relation>([[0, parsed.goal]]);
+        const freshGoal = makeRelationWithFreshLabels(parsed.goal, GOAL_GADGET_ID, "nc");
+        return new Map<CellPosition, Relation>([[0, freshGoal]]);
     }
 }
 

--- a/lib/state/slices/HoleFocus.ts
+++ b/lib/state/slices/HoleFocus.ts
@@ -1,13 +1,14 @@
+import { Term } from 'lib/game/Term';
 import { GetState, SetState } from '../Types';
 
 export interface HoleFocusState {
-  focussedHole: string | undefined
+  focussedHole: Term | undefined
   showHoleFocus: boolean
 }
 
 export interface HoleFocusActions {
   reset: () => void
-  focus: (term: string) => void
+  focus: (term: Term) => void
   removeFocus: () => void
 };
 
@@ -20,9 +21,9 @@ export const holeFocusSlice = (set: SetState<HoleFocusSlice>, get: GetState<Hole
     reset: () => {
       set({ focussedHole: undefined, showHoleFocus: true })
     },
-    focus: (variableName: string) => {
+    focus: (term: Term) => {
       if (get().showHoleFocus) {
-        set({ focussedHole: variableName })
+        set({ focussedHole: term })
       } else {
         set({ focussedHole: undefined })
       }


### PR DESCRIPTION
Resolve #16. This PR uses the number labelling introduced in #34 and determines representatives for slots as described in the commit message. 

The highlighting works on numeric holes (highlighting them, and allowing one to focus them) and across multiple gadgets: 
<img width="4238" height="773" alt="image" src="https://github.com/user-attachments/assets/a536f217-62ac-40e3-8d01-3bda6d988445" />

(This is a photo from level tim16a. I added in the grabbing hand manually, using [this](https://www.svgrepo.com/svg/372329/cursor-hand-grab) SVG). 
